### PR TITLE
add isAuthenticated() method

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -566,6 +566,7 @@ void BleKeyboard::onConnect(BLEServer* pServer) {
 
 void BleKeyboard::onDisconnect(BLEServer* pServer) {
   this->connected = false;
+  this->authenticated = false;
 
 #if !defined(USE_NIMBLE)
 

--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -101,11 +101,30 @@ BleKeyboard::BleKeyboard(const char* deviceName, const char* deviceManufacturer,
     , deviceManufacturer(String(deviceManufacturer).substring(0,15))
     , batteryLevel(batteryLevel) {}
 
+#ifndef USE_NIMBLE
+// Unfortunately, the event handler has to be a standalone function,
+// so we need this static pointer to bridge into the BleKeyboard object.
+static BleKeyboard *pme;
+static void bluedroid_gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+  if (event == ESP_GAP_BLE_AUTH_CMPL_EVT) {
+    bool success = param->ble_security.auth_cmpl.success;
+    pme->setAuthenticated(success);
+    if (!success) {
+      ESP_LOGE(LOG_TAG, "BLE GAP authentication failed, reason: %d", param->ble_security.auth_cmpl.fail_reason);
+    }
+  }
+}
+#endif
+
 void BleKeyboard::begin(void)
 {
   BLEDevice::init(deviceName.c_str());
   BLEServer* pServer = BLEDevice::createServer();
   pServer->setCallbacks(this);
+#ifndef USE_NIMBLE
+  pme = this;
+  BLEDevice::setCustomGapHandler(bluedroid_gap_event_handler);
+#endif
 
   hid = new BLEHIDDevice(pServer);
 #if defined(USE_NIMBLE)
@@ -174,6 +193,16 @@ void BleKeyboard::end(void)
 bool BleKeyboard::isConnected(void) {
   return this->connected;
 }
+
+bool BleKeyboard::isAuthenticated(void) {
+  return this->authenticated;
+}
+
+#ifndef USE_NIMBLE
+void BleKeyboard::setAuthenticated(bool isAuthenticated) {
+  this->authenticated = isAuthenticated;
+}
+#endif
 
 void BleKeyboard::setBatteryLevel(uint8_t level) {
   this->batteryLevel = level;
@@ -555,6 +584,12 @@ void BleKeyboard::onWrite(BLECharacteristic* me) {
   (void)value;
   ESP_LOGI(LOG_TAG, "special keys: %d", *value);
 }
+
+#ifdef USE_NIMBLE
+void BleKeyboard::onAuthenticationComplete(NimBLEConnInfo& connInfo) {
+  this->authenticated = true;
+}
+#endif // USE_NIMBLE
 
 void BleKeyboard::delay_ms(uint64_t ms) {
   uint64_t m = esp_timer_get_time();

--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -586,7 +586,15 @@ void BleKeyboard::onWrite(BLECharacteristic* me) {
 }
 
 #ifdef USE_NIMBLE
+// based on https://github.com/h2zero/NimBLE-Arduino/blob/master/examples/NimBLE_Server/NimBLE_Server.ino
 void BleKeyboard::onAuthenticationComplete(NimBLEConnInfo& connInfo) {
+  /** Check that encryption was successful, if not we disconnect the client */
+  if (!connInfo.isEncrypted()) {
+    NimBLEDevice::getServer()->disconnect(connInfo.getConnHandle());
+    ESP_LOGE(LOG_TAG, "Encrypt connection failed - disconnecting client\n");
+    return;
+  }
+  ESP_LOGI(LOG_TAG, "Secured connection to: %s\n", connInfo.getAddress().toString().c_str());
   this->authenticated = true;
 }
 #endif // USE_NIMBLE

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -148,6 +148,7 @@ private:
   String        deviceManufacturer;
   uint8_t            batteryLevel;
   bool               connected = false;
+  bool               authenticated = false;
   uint32_t           _delay_ms = 7;
   void delay_ms(uint64_t ms);
 
@@ -170,6 +171,10 @@ public:
   size_t write(const uint8_t *buffer, size_t size);
   void releaseAll(void);
   bool isConnected(void);
+  bool isAuthenticated(void);
+#ifndef USE_NIMBLE
+  void setAuthenticated(bool isAuthenticated);
+#endif // USE_NIMBLE
   void setBatteryLevel(uint8_t level);
   void setName(String deviceName);  
   void setDelay(uint32_t ms);
@@ -182,7 +187,6 @@ protected:
   virtual void onConnect(BLEServer* pServer) BLE_OVERRIDE;
   virtual void onDisconnect(BLEServer* pServer) BLE_OVERRIDE;
   virtual void onWrite(BLECharacteristic* me) BLE_OVERRIDE;
-
 #if defined(USE_NIMBLE)
   virtual void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) override {
     this->onConnect((BLEServer*)pServer);
@@ -193,6 +197,7 @@ protected:
   virtual void onWrite(NimBLECharacteristic* me, NimBLEConnInfo& connInfo) override {
     this->onWrite((BLECharacteristic*)me);
   }
+  virtual void onAuthenticationComplete(NimBLEConnInfo& connInfo) override;
 #endif // USE_NIMBLE
 };
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ You might also be interested in:
 - [ESP32-BLE-Mouse](https://github.com/T-vK/ESP32-BLE-Mouse)
 - [ESP32-BLE-Gamepad](https://github.com/lemmingDev/ESP32-BLE-Gamepad)
 
+## Changes from the @T-vK original
+
+- Incorporate @tiagosr compilation/clean-up changes.
+- Add isAuthenticated() method for both NimBLE and Bluedroid (necessary sometimes compared to isConnected() to avoid lost keystrokes)
 
 ## Features
 


### PR DESCRIPTION
The existing isConnected() method returns true when the BLE connection is established. However, I have found that both NimBLE and Bluedroid will lose keystrokes if you send them before the connection security has been taken care of. The new method uses callbacks/events from the BLE library to let you track when that has happened. In all my testing, I have not see any lost keystrokes when waiting for isAuthenticated before sending them. Alas, that does incur some additional delay (in the ballpark of a second).